### PR TITLE
extras: add whisper-dictation for voice-to-text on Linux/Wayland

### DIFF
--- a/extras/whisper-dictation/README.md
+++ b/extras/whisper-dictation/README.md
@@ -1,0 +1,75 @@
+# Whisper Dictation
+
+Toggle-style voice dictation using faster-whisper on NVIDIA GPUs.
+Press a key to start recording, press again to transcribe and paste.
+
+## Requirements
+
+- Linux + Wayland (KDE Plasma tested)
+- NVIDIA GPU (CUDA, no float16 needed)
+- PipeWire (for audio recording)
+- uv (Python package manager)
+
+### System packages (Fedora)
+
+```
+sudo dnf install ydotool socat wl-clipboard pipewire-utils libnotify
+```
+
+## Install
+
+```
+./bootstrap.sh
+```
+
+Then bind `~/.local/bin/dictate` to a key (e.g. F9) in your DE settings.
+
+### Model selection
+
+Set `WHISPER_MODEL` before running bootstrap to choose a different model:
+
+```
+WHISPER_MODEL=small ./bootstrap.sh    # ~460MB VRAM, faster, less accurate
+WHISPER_MODEL=medium ./bootstrap.sh   # ~1.8GB VRAM, default
+WHISPER_MODEL=large-v3 ./bootstrap.sh # ~3GB VRAM, best quality
+```
+
+Other environment variables:
+
+| Variable | Default | Options |
+|---|---|---|
+| `WHISPER_MODEL` | `medium` | `tiny`, `base`, `small`, `medium`, `large-v3` |
+| `WHISPER_DEVICE` | `cuda` | `cuda`, `cpu` |
+| `WHISPER_COMPUTE` | `int8_float32` | `float32`, `int8_float32`, `int8`, `float16` |
+
+To change the model later, edit `Environment=WHISPER_MODEL=...` in
+`~/.config/systemd/user/whisper-server.service` and run
+`systemctl --user restart whisper-server`.
+
+## How it works
+
+```
+bin/
+  dictate              # Toggle script: record -> transcribe -> paste
+  whisper-server.py    # Persistent GPU server keeping model in VRAM
+config/
+  systemd/user/
+    whisper-server.service  # Keeps whisper-server.py running
+    ydotool.service         # Keeps ydotoold running (Wayland input simulation)
+```
+
+1. `dictate` (first press): starts `pw-record`, shows "Recording..." notification
+2. `dictate` (second press): stops recording, sends WAV path to whisper-server
+   over Unix socket, copies result to clipboard, simulates Ctrl+V via ydotool
+3. `whisper-server.py`: loads the whisper model once into VRAM, listens on
+   `/tmp/whisper-server.sock`
+
+## Notes
+
+- First boot takes ~20s for the medium model to load
+- WAV files are temporary (`/tmp/dictate.wav`), deleted after transcription
+- Transcription log at `/tmp/dictate.log` (cleared on reboot)
+- Uses `nvidia-cublas-cu12` / `nvidia-cudnn-cu12` pip packages with
+  LD_LIBRARY_PATH (no system CUDA toolkit needed)
+- GPU must support the chosen compute type (e.g. GTX 1070 doesn't support
+  float16, use int8_float32 or float32)

--- a/extras/whisper-dictation/bin/dictate
+++ b/extras/whisper-dictation/bin/dictate
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Toggle-style dictation: run once to start recording, run again to stop and type.
+#
+# Files:
+#   /tmp/dictate.wav  - temporary WAV recording, deleted after transcription
+#   /tmp/dictate.pid  - PID of pw-record process (tracks recording state)
+#   /tmp/dictate.log  - append-only transcription log (persists until /tmp is cleared on reboot)
+#   /tmp/whisper-server.sock - Unix socket for whisper-server (managed by systemd)
+#
+# Nothing is kept permanently. WAVs are deleted after each transcription.
+# The log in /tmp survives the session but is cleared on reboot.
+
+PIDFILE="/tmp/dictate.pid"
+AUDIOFILE="/tmp/dictate.wav"
+SOCKET="/tmp/whisper-server.sock"
+export YDOTOOL_SOCKET="/run/user/$(id -u)/.ydotool_socket"
+
+# Clean up stale pidfile if process is dead
+if [ -f "$PIDFILE" ] && ! kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+    rm -f "$PIDFILE" "$AUDIOFILE"
+fi
+
+# If already recording, stop and transcribe
+if [ -f "$PIDFILE" ]; then
+    kill "$(cat "$PIDFILE")" 2>/dev/null
+    sleep 0.2
+    rm "$PIDFILE"
+    notify-send -t 1500 -i media-playback-pause "Dictation" "Transcribing..."
+
+    # Send audio path to whisper server, get text back
+    text=$(echo "$AUDIOFILE" | socat -t30 - UNIX-CONNECT:"$SOCKET" 2>/dev/null)
+
+    rm -f "$AUDIOFILE"
+
+    echo "$(date): Transcribed: '$text'" >> /tmp/dictate.log
+    if [ -n "$text" ] && [ "$text" != " " ]; then
+        wl-copy "$text"
+        ydotool key 29:1 47:1 47:0 29:0  # Ctrl+V
+    else
+        notify-send -t 2000 -i dialog-error "Dictation" "No transcription returned"
+    fi
+    exit 0
+fi
+
+# Check server is up before recording
+if [ ! -S "$SOCKET" ]; then
+    notify-send -t 2000 -i dialog-error "Dictation" "Whisper server not running"
+    exit 1
+fi
+
+# Start recording
+notify-send -t 1500 -i audio-input-microphone "Dictation" "Recording..."
+pw-record --format=s16 --rate=16000 --channels=1 "$AUDIOFILE" &
+echo $! > "$PIDFILE"

--- a/extras/whisper-dictation/bin/whisper-server.py
+++ b/extras/whisper-dictation/bin/whisper-server.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Persistent whisper transcription server. Keeps model in VRAM."""
+
+import socket
+import os
+from faster_whisper import WhisperModel
+
+SOCKET_PATH = "/tmp/whisper-server.sock"
+MODEL_SIZE = os.environ.get("WHISPER_MODEL", "medium")
+DEVICE = os.environ.get("WHISPER_DEVICE", "cuda")
+COMPUTE = os.environ.get("WHISPER_COMPUTE", "int8_float32")
+
+model = WhisperModel(MODEL_SIZE, device=DEVICE, compute_type=COMPUTE)
+print("Model loaded, listening on", SOCKET_PATH)
+
+if os.path.exists(SOCKET_PATH):
+    os.unlink(SOCKET_PATH)
+
+srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+srv.bind(SOCKET_PATH)
+srv.listen(1)
+
+while True:
+    conn, _ = srv.accept()
+    data = conn.recv(4096).decode().strip()
+    if not data or not os.path.exists(data):
+        conn.sendall(b"")
+        conn.close()
+        continue
+    try:
+        segments, _ = model.transcribe(data, beam_size=1, language="en")
+        text = " ".join(seg.text.strip() for seg in segments)
+    except Exception as e:
+        text = ""
+        print(f"Error: {e}")
+    try:
+        conn.sendall(text.encode())
+    except BrokenPipeError:
+        print("Client disconnected before response")
+    conn.close()

--- a/extras/whisper-dictation/bootstrap.sh
+++ b/extras/whisper-dictation/bootstrap.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap whisper dictation setup.
+# Requirements: Linux, Wayland, NVIDIA GPU, PipeWire, uv
+# Tested on: Fedora 42 + KDE Plasma 6
+#
+# Environment variables (optional):
+#   WHISPER_MODEL   - Model size: tiny, base, small, medium, large-v3 (default: medium)
+#   WHISPER_DEVICE  - Device: cuda, cpu (default: cuda)
+#   WHISPER_COMPUTE - Compute type: float32, int8_float32, int8, float16 (default: int8_float32)
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+WHISPER_MODEL="${WHISPER_MODEL:-medium}"
+
+echo "=== Whisper Dictation Bootstrap (model: $WHISPER_MODEL) ==="
+
+# Check prerequisites
+for cmd in pw-record socat wl-copy notify-send uv; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Missing: $cmd"
+        echo "Install with: sudo dnf install pipewire-utils socat wl-clipboard libnotify uv"
+        exit 1
+    fi
+done
+
+if ! command -v ydotool &>/dev/null; then
+    echo "Missing: ydotool"
+    echo "Install with: sudo dnf install ydotool"
+    exit 1
+fi
+
+if ! nvidia-smi &>/dev/null; then
+    echo "No NVIDIA GPU detected. This setup requires CUDA."
+    exit 1
+fi
+
+# Create venv with faster-whisper
+VENV="$HOME/.local/share/venvs/whisper"
+if [ ! -d "$VENV" ]; then
+    echo "Creating whisper venv..."
+    uv venv "$VENV"
+fi
+echo "Installing faster-whisper..."
+uv pip install --python "$VENV/bin/python" faster-whisper nvidia-cublas-cu12 nvidia-cudnn-cu12
+
+# Find NVIDIA lib paths for LD_LIBRARY_PATH in systemd service
+NVIDIA_LIBS=$("$VENV/bin/python" -c "
+import os, nvidia.cublas, nvidia.cudnn
+cublas = os.path.join(nvidia.cublas.__path__[0], 'lib')
+cudnn = os.path.join(nvidia.cudnn.__path__[0], 'lib')
+print(cublas + ':' + cudnn)
+")
+
+# Install scripts
+echo "Installing scripts to ~/.local/bin/..."
+install -m755 "$DIR/bin/dictate" "$HOME/.local/bin/dictate"
+install -m755 "$DIR/bin/whisper-server.py" "$HOME/.local/bin/whisper-server.py"
+
+# Install systemd services
+echo "Installing systemd user services..."
+mkdir -p "$HOME/.config/systemd/user"
+
+cp "$DIR/config/systemd/user/ydotool.service" "$HOME/.config/systemd/user/ydotool.service"
+
+# whisper-server needs LD_LIBRARY_PATH for NVIDIA pip libs — patch the service file
+WHISPER_ENVS="Environment=LD_LIBRARY_PATH=$NVIDIA_LIBS"
+WHISPER_ENVS="$WHISPER_ENVS\nEnvironment=WHISPER_MODEL=${WHISPER_MODEL}"
+[ -n "${WHISPER_DEVICE:-}" ] && WHISPER_ENVS="$WHISPER_ENVS\nEnvironment=WHISPER_DEVICE=${WHISPER_DEVICE}"
+[ -n "${WHISPER_COMPUTE:-}" ] && WHISPER_ENVS="$WHISPER_ENVS\nEnvironment=WHISPER_COMPUTE=${WHISPER_COMPUTE}"
+sed "s|^ExecStart=.*|${WHISPER_ENVS}\nExecStart=$VENV/bin/python $HOME/.local/bin/whisper-server.py|" \
+    "$DIR/config/systemd/user/whisper-server.service" > "$HOME/.config/systemd/user/whisper-server.service"
+
+# Enable and start services
+systemctl --user daemon-reload
+systemctl --user enable --now ydotool.service
+systemctl --user enable --now whisper-server.service
+
+echo ""
+echo "=== Done ==="
+echo "The whisper model takes ~20s to load on first start."
+echo "Bind ~/.local/bin/dictate to a key (e.g. F9) in your DE settings."
+echo "Press once to record, press again to stop and paste transcription."

--- a/extras/whisper-dictation/config/systemd/user/whisper-server.service
+++ b/extras/whisper-dictation/config/systemd/user/whisper-server.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Whisper transcription server
+
+[Service]
+Type=simple
+Restart=always
+Environment=LD_LIBRARY_PATH=/home/cay/.local/share/venvs/whisper/lib/python3.13/site-packages/nvidia/cublas/lib:/home/cay/.local/share/venvs/whisper/lib/python3.13/site-packages/nvidia/cudnn/lib
+ExecStart=/home/cay/.local/share/venvs/whisper/bin/python /home/cay/.local/bin/whisper-server.py
+
+[Install]
+WantedBy=default.target

--- a/extras/whisper-dictation/config/systemd/user/ydotool.service
+++ b/extras/whisper-dictation/config/systemd/user/ydotool.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=ydotoold - ydotool daemon
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/ydotoold
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- Adds `extras/whisper-dictation/` — a self-contained voice dictation setup for Linux/Wayland + NVIDIA GPUs
- Persistent faster-whisper server keeps model in VRAM, toggle script records via PipeWire and pastes via ydotool
- Includes bootstrap script, systemd services, configurable model selection via env vars, and README

## Structure
```
extras/whisper-dictation/
├── README.md
├── bootstrap.sh
├── bin/
│   ├── dictate
│   └── whisper-server.py
└── config/
    └── systemd/
        └── user/
            ├── whisper-server.service
            └── ydotool.service
```

## Test plan
- [ ] Run `bootstrap.sh` on a fresh Fedora + NVIDIA machine
- [ ] Verify `dictate` toggle records and transcribes correctly
- [ ] Test model selection via `WHISPER_MODEL=small ./bootstrap.sh`
- [ ] Confirm services survive reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)