### PR TITLE
claude-with: error on empty selection and portable mktemp

### DIFF
--- a/bin/scripts/claude-with
+++ b/bin/scripts/claude-with
@@ -22,6 +22,11 @@ fi
 
 selected=$(printf '%s\n' "$available" | gum choose --no-limit --header "MCP servers for this session" || true)
 
+if [[ -z "${selected//[[:space:]]/}" ]]; then
+    echo "claude-with: no servers selected — did you forget to hit space?" >&2
+    exit 1
+fi
+
 keys_json=$(printf '%s\n' "$selected" | jq -R . | jq -s 'map(select(length > 0))')
 config=$(jq --argjson keys "$keys_json" '{mcpServers: with_entries(select(.key as $k | $keys | index($k)))}' "$DEFINITIONS")
 
@@ -37,7 +42,7 @@ for var in $(grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' <<< "$config" | sed -E 's/[$\{\}]
     config="${config//\$\{$var\}/${!var:-}}"
 done
 
-tmp=$(mktemp -t claude-mcp).json
+tmp=$(mktemp "${TMPDIR:-/tmp}/claude-mcp.XXXXXX").json
 printf '%s\n' "$config" > "$tmp"
 
 # Drop a leading literal "claude" so an existing invocation can be prefixed


### PR DESCRIPTION
## Summary
- Exit with a clear hint (\"did you forget to hit space?\") when `gum choose` returns no selections — easy to miss that spacebar is required for multi-select.
- Switch `mktemp -t` to an explicit `${TMPDIR:-/tmp}/claude-mcp.XXXXXX` template so the script works on both GNU coreutils and BSD/macOS mktemp.

## Test plan
- [ ] Run `claude-with`, confirm at the gum prompt without selecting anything → see the new error and non-zero exit.
- [ ] Run `claude-with`, spacebar-select a server, confirm → claude launches as before.
- [ ] Sanity-check on macOS that the mktemp template still produces a usable temp file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)