### PR TITLE
claude-with: empty selection guard + cay bootstrap/skill fixes

### DIFF
--- a/bin/scripts/claude-with
+++ b/bin/scripts/claude-with
@@ -52,6 +52,11 @@ if [[ -n "$LOCAL_LABEL" ]] && grep -qxF "$LOCAL_LABEL" <<< "$selected"; then
     selected=$(grep -vxF "$LOCAL_LABEL" <<< "$selected" || true)
 fi
 
+if [[ -z "${selected//[[:space:]]/}" ]]; then
+    echo "claude-with: no servers selected — did you forget to hit space?" >&2
+    exit 1
+fi
+
 keys_json=$(printf '%s\n' "$selected" | jq -R . | jq -s 'map(select(length > 0))')
 config=$(jq --argjson keys "$keys_json" '{mcpServers: with_entries(select(.key as $k | $keys | index($k)))}' "$DEFINITIONS")
 
@@ -72,7 +77,7 @@ for var in $(grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' <<< "$config" | sed -E 's/[$\{\}]
     config="${config//\$\{$var\}/${!var:-}}"
 done
 
-tmp=$(mktemp -t claude-mcp).json
+tmp=$(mktemp "${TMPDIR:-/tmp}/claude-mcp.XXXXXX").json
 printf '%s\n' "$config" > "$tmp"
 
 # Drop a leading literal "claude" so an existing invocation can be prefixed

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -381,11 +381,18 @@ function create_links {
   ln -sf "$DOTS_CONFIG_DIR/bash" "$CONFIG_DIR" || _fail_error "Failed to symlink bash config"
   ln -sf "$DOTS_CONFIG_DIR/claude-mcp" "$CONFIG_DIR" || _fail_error "Failed to symlink claude-mcp config"
   ln -sf "$DOTS_CONFIG_DIR/input" "$CONFIG_DIR" || _fail_error "Failed to symlink input config"
-  ln -sf "$DOTS_CONFIG_DIR/lazygit" "$CONFIG_DIR" || _fail_error "Failed to symlink lazygit config"
+  if [[ "$USER" != "cay" ]]; then
+    ln -sf "$DOTS_CONFIG_DIR/lazygit" "$CONFIG_DIR" || _fail_error "Failed to symlink lazygit config"
+  fi
   ln -sf "$DOTS_CONFIG_DIR/karabiner" "$CONFIG_DIR" || _fail_error "Failed to symlink karabiner config"
   ln -sf "$DOTS_CONFIG_DIR/nvim" "$CONFIG_DIR" || _fail_error "Failed to symlink nvim config"
-  ln -sf "$DOTS_CONFIG_DIR/git" "$CONFIG_DIR" || _fail_error "Failed to symlink git config"
-  ln -sf "$DOTS_CONFIG_DIR/systemd" "$CONFIG_DIR" || _fail_error "Failed to symlink systemd config"
+  ln -sf "$DOTS_CONFIG_DIR/opencode" "$CONFIG_DIR" || _fail_error "Failed to symlink opencode config"
+  if [[ "$USER" != "cay" ]]; then
+    ln -sf "$DOTS_CONFIG_DIR/git" "$CONFIG_DIR" || _fail_error "Failed to symlink git config"
+  fi
+  if [[ "$USER" != "cay" ]]; then
+    ln -sf "$DOTS_CONFIG_DIR/systemd" "$CONFIG_DIR" || _fail_error "Failed to symlink systemd config"
+  fi
   ln -sf "$DOTS_CONFIG_DIR/selinux" "$CONFIG_DIR" || _fail_error "Failed to symlink selinux config"
   ln -sf "$DOTS_CONFIG_DIR/ghostty" "$CONFIG_DIR" || _fail_error "Failed to symlink ghostty config"
 

--- a/config/claude/skills/notion-recipes/SKILL.md
+++ b/config/claude/skills/notion-recipes/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: notion-recipes
-description: Use this skill when adding, querying, or updating recipes in Cay's Notion (the `notion-wife` MCP). Covers the Recipes data source schema, tag conventions, the `recipes-helper.sh` script for fast tag/recipe operations via curl, and the rule that new tags must be confirmed with the user before creation.
+description: Use this skill when adding, querying, or updating recipes in Cay's Notion (the `notion-wife` MCP, OR the OAuth `mcp__notion__*` MCP when $USER is cay). Covers the Recipes data source schema, tag conventions, the `recipes-helper.sh` script for fast tag/recipe operations via curl, and the rule that new tags must be confirmed with the user before creation.
 ---
 
 # Cay's Notion Recipes
 
-For working with Cayleigh's Notion workspace via the token-based `notion-wife` MCP. Pair with **notion-rest-tricks** for the underlying API patterns.
+For working with Cayleigh's Notion workspace. Pair with **notion-rest-tricks** for the underlying API patterns when using the token-based MCP.
+
+## Which MCP to use
+
+- **If `$USER` is `cay`**: she connects to her own Notion via the **OAuth** `mcp__notion__*` server. Use those tools (`mcp__notion__notion-search`, `notion-fetch`, `notion-create-pages`, `notion-update-page`, `notion-create-comment`, etc.). The schema, tag conventions, and "ask before creating new tags" rule below all still apply — only the transport changes.
+- **Otherwise** (e.g. Alex driving from his account): use the token-based `mcp__notion-wife__API-*` MCP and `recipes-helper.sh` (which depends on `NOTION_TOKEN_WIFE`).
+
+The schema/tag/workflow content below is workspace-specific and applies regardless of transport. Tool-name examples are written for the token MCP; translate to OAuth equivalents when `$USER=cay`. The `recipes-helper.sh` script and `notion-rest-tricks` skill are token-only — skip them under OAuth.
 
 ## The Recipes database
 
@@ -43,6 +50,13 @@ Tags fall into rough buckets — pick liberally from existing tags. Common group
 
 Be aware some tags have typos (`Potatoe`, `Alochol`, `suace`). Use them as-is — don't rename them; that risks losing the relation on existing recipes.
 
+## **RULE: don't use the `Made` tag**
+
+**Do not add the `Made` tag to recipes.** To mark a recipe as cooked, set the `Recipe Cooked` checkbox property to true instead.
+
+- **Why**: `Made` and `Recipe Cooked` are redundant; Cay tracks cooked-status via the checkbox, and the tag is legacy/noise. Per-user preference (Cay, 2026-05-07).
+- **How to apply**: When tagging a recipe Cay has cooked, omit `Made` from the Tags list and set `Recipe Cooked: __YES__` (token API) / `"Recipe Cooked": "__YES__"` (OAuth update_properties). Same applies to retroactive cleanup if you spot `Made` on a recipe you're editing — drop it.
+
 ## **RULE: new tags require user permission**
 
 **Do not create new tags without asking the user first.** Assigning *existing* tags to recipes is fine.
@@ -71,8 +85,18 @@ Color must be one of: `default, gray, brown, orange, yellow, green, blue, purple
 
 ## Workflow: adding a recipe
 
+### Token MCP (Alex / non-cay user)
+
 1. **Search first** — `recipes-helper.sh find-recipe <name>` to confirm it doesn't already exist.
 2. **Pick tags** — start from the conventions above; use `list-tags <substring>` to verify spellings. If a needed tag is missing, **stop and ask the user** before adding.
 3. **Create the page** via `mcp__notion-wife__API-post-page` with parent `{type: "database_id", database_id: "9730ecb7-e605-4da8-989c-5e95edd423fa"}`, an emoji icon, Name + Tags + (optionally Link, Status).
 4. **Append the body** via `mcp__notion-wife__API-patch-block-children` — ingredients as `bulleted_list_item`, method as bullets or paragraphs, notes section at the end.
+5. **Return the URL** so the user can review/edit.
+
+### OAuth MCP (`$USER=cay`)
+
+1. **Search first** — `mcp__notion__notion-search` for the recipe name to confirm it doesn't already exist. To list/check existing tags, `mcp__notion__notion-fetch` the Recipes data source URL/ID and inspect the `Tags` schema (or use the search-within-data-source flow).
+2. **Pick tags** — same conventions as above. If a needed tag is missing, **stop and ask the user** before adding (and use `mcp__notion__notion-update-data-source` with the *full* options list to add it — same wipe-existing-tags trap as the token API).
+3. **Create the page** via `mcp__notion__notion-create-pages` with the Recipes data source as parent. The OAuth server accepts Markdown-frontmatter style properties — set Name, Tags, Link, Status there.
+4. **Body content** can be passed as Markdown in the same `notion-create-pages` call (the OAuth server speaks Notion-flavoured Markdown), or appended afterward with `notion-update-page`.
 5. **Return the URL** so the user can review/edit.

--- a/config/claude/skills/notion-rest-tricks/SKILL.md
+++ b/config/claude/skills/notion-rest-tricks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notion-rest-tricks
-description: Use this skill when working with the token-based Notion MCP servers (e.g. `mcp__notion-wife__API-*`) that wrap the raw Notion REST API — distinct from the OAuth `mcp__notion__*` server covered by notion-tricks. Covers native API JSON property shapes, the two-step page-then-content creation flow, and using `curl` with the `NOTION_TOKEN_*` env var to bypass MCP entirely for bulk/precise operations.
+description: Use this skill when working with the token-based Notion MCP servers (e.g. `mcp__notion-wife__API-*`) that wrap the raw Notion REST API — distinct from the OAuth `mcp__notion__*` server covered by notion-tricks. Covers native API JSON property shapes, the two-step page-then-content creation flow, and using `curl` with the `NOTION_TOKEN_*` env var to bypass MCP entirely for bulk/precise operations. Skip when `$USER=cay` and only the OAuth `mcp__notion__*` server is connected.
 ---
 
 # Notion REST MCP Tricks
@@ -8,6 +8,8 @@ description: Use this skill when working with the token-based Notion MCP servers
 For token-based MCP servers built on `@notionhq/notion-mcp-server` (e.g. `notion-wife`). These expose the raw Notion REST API: tools are named `API-post-page`, `API-query-data-source`, `API-patch-block-children`, etc.
 
 If you're using the OAuth `mcp__notion__*` server (which speaks Notion-flavoured Markdown), see **notion-tricks** instead. The two skills overlap deliberately — pick the one that matches the server you're calling.
+
+**When `$USER=cay`**: she connects to her own Notion (the same workspace `notion-wife` would target) via the OAuth `mcp__notion__*` server. Skip this skill — none of the `API-*` tool names or `NOTION_TOKEN_WIFE`-based curl commands apply unless she's explicitly invoked the token MCP. For her recipe/Notion work, use **notion-recipes** + OAuth tools.
 
 ## Property shape: native Notion API JSON, not Markdown
 


### PR DESCRIPTION
## Summary

- `claude-with`: error on empty fzf selection instead of silently launching with no MCPs (portable `mktemp` fix included)
- `bootstrap.sh`: skip lazygit, git config, and systemd symlinks when `$USER=cay` (her machine has its own config for these)
- `claude/skills`: route Cay's Notion work to the OAuth `mcp__notion__*` MCP when `$USER=cay`; add "don't use Made tag" rule to notion-recipes

## Test plan
- [ ] Run `claude-with` and hit enter without selecting anything — should print an error and exit
- [ ] Run bootstrap on cay's machine — lazygit/git/systemd symlinks should be skipped

🤖 Generated with [Claude Code](https://claude.ai/claude-code)